### PR TITLE
Use inequality for packaging dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.7"
 # copied from marshmallow
-packaging = "^17.0"
+packaging = ">=17.0"
 
 [tool.poetry.dev-dependencies]
 # updating to a11 breaks everything for some reason, probably a cython bug


### PR DESCRIPTION
The upstream marshmallow source requires packaging >=17.0, but specifying this as "^17.0" results in ">=17.0 <18.0" which is incorrect and results in package dependency resolution failures when other packages require higher versions of packaging.

This change aligns the poetry metadata to the upstream marshmallow requirements using the proper inequality