### PR TITLE
Workflow to support aarch64 for Linux distros

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -87,9 +87,10 @@ jobs:
           python -m pip install pipx
           python -m pipx ensurepath
       - name: Set up QEMU
+        if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v2
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.10.1
+        uses: pypa/cibuildwheel@v2.12.0
         with:
           output-dir: dist
         env:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -93,6 +93,7 @@ jobs:
         env:
           # most CIBW_* vars are in pyproject.toml
           DISTUTILS_DEBUG: '1'
+          CIBW_ARCHS_LINUX: "auto aarch64"
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
       - uses: actions/upload-artifact@v2
         if: ${{ !env.ACT }}

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -53,6 +53,8 @@ jobs:
         buildplat:
           - [ubuntu-20.04, manylinux_x86_64]
           - [ubuntu-20.04, musllinux_x86_64]
+          - [ubuntu-20.04, manylinux_aarch64]
+          - [ubuntu-20.04, musllinux_aarch64]
           - [macos-11, macosx_x86_64]
           # not supported by github actions, see
           # https://github.com/actions/virtual-environments/issues/2187

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -86,6 +86,8 @@ jobs:
         run: |
           python -m pip install pipx
           python -m pipx ensurepath
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.10.1
         with:


### PR DESCRIPTION
Hi,
we use your excellent fork of marshmallow, thank you for that. However, we work with embedded devices which typically run on arm64 architectures. The easiest approach for us will be if the wheels for althaia are built automatically for `arm64` using your pipeline. 

With this pull request I've added this option, where 1) `aarch64` is emulated using `qemu`, and 2) `aarch64` wheels are built using the `manylinux` and `musllinux` images only. The reason is that building of `arm64` wheels for Windows is still experimental (https://github.com/pypa/cibuildwheel#what-does-it-do) and building of `arm64` wheels for MacOS is possible, but not supported by the `setup-qemu-action` (https://github.com/docker/setup-qemu-action) required to emulate `arm64` architecture. Let me know if you'll consider adding this to your build pipeline. 

The cost of accepting this pull request is that arm64 emulation makes the arm64 'paths' take longer, typically between 20 to 30 minutes. A successful run of your pipeline which includes aarch64 builds can be found here: https://github.com/hvalev/python-althaia/actions/runs/4045655001/jobs/6957419669. The duration is partly influenced by having to build psutil (and sometimes cffi depending on the python version) for arm64.